### PR TITLE
Spark streaming topic

### DIFF
--- a/spark/spark-streaming-topic/README.md
+++ b/spark/spark-streaming-topic/README.md
@@ -1,0 +1,11 @@
+# Spark Streaming Topic 
+
+This folder contains two contents: 
+
+1. how spark streaming integrated with different data middlewares like local file, hdfs file, redis, kafka, elasticsearch and hbase
+2. how spark streaming implements customized receiver that supports different data sources 
+3. spark streaming supports regular and advanced spark DStream operations
+4. how spark streaming save data to different downstreams like, redis, kafka, elasticsearch and hbase 
+
+
+For installation of different middle ware's simplisity we establish all the clusters in `Dockerfile` or `docker-compose.yml` those with minimum worker nodes (which performace cannot compare to product envs). 

--- a/spark/spark-streaming-topic/spark-streaming-pro/pom.xml
+++ b/spark/spark-streaming-topic/spark-streaming-pro/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.emma</groupId>
+    <artifactId>spark-streaming-topic</artifactId>
+    <version>1.0</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <spark.version>3.4.1</spark.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.11</artifactId>
+            <version>2.4.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.12</artifactId>
+            <version>3.4.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>2.7.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>spark.streaming.StreamingExample</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/AggErrorCount.java
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/AggErrorCount.java
@@ -1,0 +1,80 @@
+package org.emma.spark.streaming.topic;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.Optional;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.spark.serializer.KryoSerializer;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class AggErrorCount implements Serializable {
+    public static void main(String[] args) throws InterruptedException {
+        SparkConf conf = new SparkConf().setMaster("local[2]")
+                .setAppName("AggErrorCount")
+                .set("spark.serializer", KryoSerializer.class.getName());
+
+        // here set batch interval 5ms
+        JavaStreamingContext jssc = new JavaStreamingContext(conf, new Duration(1000));
+
+        // set checkpoint, NEEDED for update state by key operation
+        jssc.checkpoint("tmp/spark");
+
+        // define the socket where the system will listen lines
+        // is not a rdd but a sequence of rdd, not static, constantly changing
+        JavaReceiverInputDStream<String> lines = jssc.socketTextStream(args[0], Integer.parseInt(args[1]));
+
+        // split each line into words
+        JavaDStream<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
+            @Override
+            public Iterator<String> call(String s) throws Exception {
+                return Arrays.stream(s.split(" ")).iterator();
+            }
+        });
+
+        // filter using the lines containing errors
+        JavaDStream<String> filterWords = lines.filter(item -> item.contains("ERROR"));
+
+        // here convert each words into pairs in which key is the word,
+        // value is the init count in the context of the streaming
+        JavaPairDStream<String, Integer> pairs = filterWords.mapToPair(
+                new PairFunction<String, String, Integer>() {
+                    @Override
+                    public Tuple2<String, Integer> call(String s) throws Exception {
+                        return new Tuple2<>(s, 1);
+                    }
+                }
+        );
+
+        // aggregates all values in the global context instead of
+        // in the grain of 1000s windows period.
+
+        // the value of the state in the function is referring to the number of the micro-batch that with the step of the 1000s duration window.
+        JavaPairDStream<String, Integer> wordCounts = pairs.updateStateByKey(new Function2<List<Integer>, Optional<Integer>, Optional<Integer>>() {
+            @Override
+            public Optional<Integer> call(List<Integer> values, Optional<Integer> state) throws Exception {
+                Integer newSum = values.stream().reduce(0, Integer::sum);
+                if (state != null && state.isPresent()) {
+                    newSum += state.get();
+                }
+                return Optional.of(newSum);
+            }
+        });
+
+        // in remain codes will try write the datasets to other middle wares like kfk, es..
+        wordCounts.print();
+
+        jssc.start();
+        jssc.awaitTermination();
+    }
+}

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/BasicErrorCount.java
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/BasicErrorCount.java
@@ -1,0 +1,66 @@
+package org.emma.spark.streaming.topic;
+
+import com.twitter.chill.KryoSerializer;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class BasicErrorCount implements Serializable {
+    public static void main(String[] args) throws InterruptedException {
+        SparkConf conf = new SparkConf().setMaster("")
+                .setAppName("BasicErrorCount")
+                .set("spark.serializer", KryoSerializer.class.getName());
+
+        // set batch interval 5ms
+        JavaStreamingContext jssc = new JavaStreamingContext(conf, new Duration(10000));
+
+        // define the socket where the system will listen to
+        JavaReceiverInputDStream<String> lines = jssc.socketTextStream(args[0], Integer.parseInt(args[1]));
+
+        // split each line into words
+        JavaDStream<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
+            @Override
+            public Iterator<String> call(String s) throws Exception {
+                return Arrays.stream(s.split("  ")).iterator();
+            }
+        });
+
+
+        // filter using the lines containing errors
+        JavaDStream<String> filteredWords = lines.filter(word -> word.contains("ERROR"));
+
+        // then count each word in each batch
+        JavaPairDStream<String, Integer> pairs = filteredWords.mapToPair(new PairFunction<String, String, Integer>() {
+            @Override
+            public Tuple2<String, Integer> call(String s) throws Exception {
+                // here set the init count value for inputting string value
+                return new Tuple2<String, Integer>(s, 1);
+            }
+        });
+
+        // aggregate each value
+        JavaPairDStream<String, Integer> wordCounts = pairs.reduceByKey(new Function2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer count1, Integer count2) throws Exception {
+                return (count1 + count1);
+            }
+        });
+
+        // here print the first ten elements of each RDD generated in this DStream to the console
+        wordCounts.print();
+
+        jssc.start();
+        jssc.awaitTermination();
+    }
+}

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/WindowAndKeyErrorCount.java
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/WindowAndKeyErrorCount.java
@@ -1,0 +1,86 @@
+package org.emma.spark.streaming.topic;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFunction;
+import org.apache.spark.serializer.KryoSerializer;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.Durations;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class WindowAndKeyErrorCount implements Serializable {
+    public static void main(String[] args) throws InterruptedException {
+        SparkConf conf = new SparkConf().setMaster("local[2]")
+                .setAppName("WindowAndKeyErrorCount")
+                .set("spark.serializer", KryoSerializer.class.getName());
+
+
+
+        // batch interval 5ms
+        JavaStreamingContext jssc = new JavaStreamingContext(conf, new Duration(1000));
+
+
+        // here we set path that to let the spark streaming context know where the checkpoint locates
+        // increase the spark job restart to re-consume dataset from
+
+        // CHECKPOINT, NEEDED FOR UPDATE STATE BY KEY OPERATION
+        jssc.checkpoint("tmp/spark");
+
+        // all dataset is consumed from the socket listener
+        // lines is not a rdd but a sequence of rdd, not static, constantly chaning
+        JavaReceiverInputDStream<String> lines = jssc.socketTextStream(args[0], Integer.parseInt(args[1]));
+
+        // split each line into words
+        JavaDStream<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
+            @Override
+            public Iterator<String> call(String s) throws Exception {
+                return Arrays.stream(s.split(" ")).iterator();
+            }
+        });
+
+        // filter using the lines containing errors
+        JavaDStream<String> filteredWords = lines.filter(word -> word.contains("ERROR"));
+
+        // count each word in each batch
+        JavaPairDStream<String, Integer> pairs = filteredWords.mapToPair(new PairFunction<String, String, Integer>() {
+            @Override
+            public Tuple2<String, Integer> call(String s) throws Exception {
+                return new Tuple2<>(s, 1);
+            }
+        });
+
+        // here we execute reduce operation upon each rdds from the DStream
+        // here we create a window which accumulates from multiple DStream that with the duration step value = 5 milliseconds
+        // which means we collect small fractions of DStream items into Windows, and re-organize the DStreams in the period of Windows.
+
+        // and execute reduce operation in the grain of window
+
+        // the first params of the duration is the window duration which means the length of the window.
+        // and the second param of the duration is the slide step length
+
+        // e.g. if we set the window length = 5 seconds, which means the window contains all the DStreams that [0, 5]
+        // and with the slide window length = 10, if the first window is [0,5] the next window is [10, 15] [w_start + slide_window_len, w_end + slide_window_len]
+        // and always keep the w_end - w_start = 5
+        JavaPairDStream<String, Integer> windowedWordCounts = pairs.reduceByKeyAndWindow(new Function2<Integer, Integer, Integer>() {
+            @Override
+            public Integer call(Integer val1, Integer val2) throws Exception {
+                return (val1 + val2);
+            }
+        }, Durations.seconds(5), Durations.seconds(10));
+
+        // print the first ten elements of each RDD generated in this DStream to the console
+        windowedWordCounts.print();
+
+        jssc.start();
+        jssc.awaitTermination();
+    }
+}

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/WindowErrorCount.java
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/WindowErrorCount.java
@@ -1,0 +1,56 @@
+package org.emma.spark.streaming.topic;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.serializer.KryoSerializer;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class WindowErrorCount implements Serializable {
+    public static void main(String[] args) throws InterruptedException {
+        SparkConf conf = new SparkConf().setMaster("local[2]")
+                .setAppName("WindowErrorCount")
+                .set("spark.serializer", KryoSerializer.class.getName());
+
+        // batch interval 5ms
+        JavaStreamingContext jssc = new JavaStreamingContext(conf, new Duration(1000));
+
+        // CHECKPOINT, NEEDED FOR UPDATE STATE BY KEY OPERATION
+        jssc.checkpoint("tmp/spark");
+
+        // define the socket where the system will listen
+        // And the lines is not a rdd but a sequence of rdd, not static, constantly changing
+        JavaReceiverInputDStream<String> lines = jssc.socketTextStream(args[0], Integer.parseInt(args[1]));
+
+        // here we split each line into words
+        JavaDStream<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
+            @Override
+            public Iterator<String> call(String s) throws Exception {
+                return Arrays.stream(s.split(" ")).iterator();
+            }
+        });
+
+        // filter using the lines containing errors
+        JavaDStream<String> filteredWords = lines.filter(item -> item.contains("ERROR"));
+
+        // count each word in each batch
+        JavaPairDStream<String, Integer> pairs = filteredWords.mapToPair(item -> new Tuple2<>(item, 1));
+
+        // window count USING THE SIZE AND THE SLIDIND INTERVAL
+        JavaDStream<Long> wordCounts = pairs.countByWindow(new Duration(5000), new Duration(10000));
+
+        // print the first ten elements of each RDD generated in the DStream to the console
+        wordCounts.print();
+
+        jssc.start();
+        jssc.awaitTermination();
+    }
+}

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/WordCount.java
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/java/org/emma/spark/streaming/topic/WordCount.java
@@ -1,0 +1,49 @@
+package org.emma.spark.streaming.topic;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.serializer.KryoSerializer;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.api.java.JavaStreamingContext$;
+import scala.Tuple2;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class WordCount {
+    public static void main(String[] args) throws InterruptedException {
+        SparkConf conf = new SparkConf().setMaster("local[2]")
+                .setAppName("WordCount")
+                .set("spark.serializer", KryoSerializer.class.getName());
+
+        // batch interval 5ms
+        JavaStreamingContext jssc = new JavaStreamingContext(conf, new Duration(5000));
+
+        // here we define the socket where the system will listen
+        // and here the lines return by the jssc#socketTextStream is not rdd but a sequence of rdd, not static, constantly changing.
+        JavaReceiverInputDStream<String> lines = jssc.socketTextStream(args[0], Integer.parseInt(args[1]));
+
+        // split each line into words
+        JavaDStream<String> words = lines.flatMap(new FlatMapFunction<String, String>() {
+            @Override
+            public Iterator<String> call(String s) throws Exception {
+                return Arrays.stream(s.split(" ")).iterator();
+            }
+        });
+
+        // count each word in each batch
+        JavaPairDStream<String, Integer> pairs = words.mapToPair(item -> new Tuple2<>(item, 1));
+
+        // aggregate all the sum of each batch --> and this batch is different from previous windows or with the state.
+        // this batch only in the scope of one Duration
+        JavaPairDStream<String, Integer> wordCounts = pairs.reduceByKey((val1, val2) -> (val1 + val2));
+
+        // here we print the first ten elements of each RDD generated in this DStream to the console
+        jssc.start();
+        jssc.awaitTermination();
+    }
+}

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/resources/log4j.properties
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/resources/log4j.properties
@@ -1,0 +1,16 @@
+# Root logger option
+log4j.rootLogger=WARN, console
+
+# Direct log messages to the console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+#log4j.logger.com.foo=WARN
+log4j.logger.org.apache.spark.scheduler=ERROR
+log4j.logger.org.apache.spark.executor=ERROR
+log4j.logger.org.apache.spark.storage=ERROR
+log4j.logger.org.apache.spark.streaming.scheduler=ERROR
+log4j.logger.org.apache.spark.streaming.receiver=ERROR
+log4j.logger.org.apache.spark.streaming.twitter=ERROR


### PR DESCRIPTION
add spark streaming topic that includes
1. Implement and test streaming `DStream` basic APIs operation 
2. Wriet checkpoint data to other data framework like redis, zookeeper or kafka by extend class of `CheckpointWriter`
3. Supporting the subscription of datasets from upstream components for various data frameworks and writing data results. Experimenting with different serialization types and serializing computed data objects.