### PR TITLE
udpate

### DIFF
--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/scala/org/emma/spark/streaming/topic/internal/Logging.scala
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/scala/org/emma/spark/streaming/topic/internal/Logging.scala
@@ -1,0 +1,274 @@
+package org.emma.spark.streaming.topic.internal
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.appender.ConsoleAppender
+import org.apache.logging.log4j.core.config.DefaultConfiguration
+import org.apache.logging.log4j.core.filter.AbstractFilter
+import org.apache.logging.log4j.core.{Filter, LifeCycle, LogEvent, LoggerContext, Logger => Log4jLogger}
+import org.emma.spark.streaming.topic.internal.Logging.SparkShellLoggingFilter
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters.mapAsScalaMapConverter
+
+/**
+ * Utility trait for classes that want to log data. Creates a SLF4J logger for the class and allows
+ * logging messages at different levels using methods that only evaluate parameters lazily if the
+ * log level is enabled.
+ */
+trait Logging {
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used an another machine
+  @transient private var log_ : Logger = null
+
+  // Method to get the logger name for this object
+  protected def logName = {
+    // Ignore trailing $'s in the class name for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Method to get or create the logger for this object
+  protected def log: Logger = {
+    if (log_ == null) {
+      initializeLogIfNecessary(false)
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+  // Log methods that take onl a String
+  protected def logInfo(msg: => String): Unit = {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String): Unit = {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  protected def logWarning(msg: => String): Unit = {
+    if (log.isTraceEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String): Unit = {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable): Unit = {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable): Unit = {
+    if (log.isErrorEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable): Unit = {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable): Unit = {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable): Unit = {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+
+  protected def isTraceEnabled(): Boolean = {
+    log.isTraceEnabled
+  }
+
+  protected def initializeLogIfNecessary(isInterpreter: Boolean): Unit = {
+    initializeLogIfNecessary(isInterpreter, silent = false)
+  }
+
+  protected def initializeLogIfNecessary(isInterpreter: Boolean, silent: Boolean): Boolean = {
+    if (!Logging.initialized) {
+      Logging.initLock.synchronized {
+        if (!Logging.initialized) {
+          initializeLogging(isInterpreter, silent)
+          return true;
+        }
+      }
+    }
+    return false
+  }
+
+  private def initializeForcefully(isInterpreter: Boolean, silent: Boolean): Unit = {
+
+  }
+
+  private def initializeLogging(isInterpreter: Boolean, silent: Boolean): Unit = {
+    if (Logging.isLog4j2()) {
+      val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
+      // If Log4j 2 is used but is initialized by default configuration,
+      // load a default properties file
+      if (Logging.islog4j2DefaultConfigured()) {
+        Logging.defaultSparkLog4jConfig = true
+        val defaultLogProps = "org/apache/spark/log4j2-defaults.properties"
+        Option(SparkClassUtils.getSparkClassLoader.getResource(defaultLogProps)) match {
+          case Some(url) =>
+            val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+            context.setConfigLocation(url.toURI)
+            if (!silent) {
+              System.err.println(s"Using Spark's default log4j profile: $defaultLogProps")
+              Logging.setLogLevelPrinted = true
+            }
+          case None =>
+            System.err.println(s"Spark was unable to load $defaultLogProps")
+        }
+      }
+
+      if (Logging.defaultRootLevel == null) {
+        Logging.defaultRootLevel = rootLogger.getLevel()
+      }
+
+      if (isInterpreter) {
+        // Use the repl's main class to define the default log level when running the shell,
+        // overriding the root logger's config if they're different.
+        val replLogger = LogManager.getLogger(logName).asInstanceOf[Log4jLogger]
+        val replLevel = if (Logging.loggerWithCustomConfig(replLogger)) {
+          replLogger.getLevel()
+        } else {
+          Level.WARN
+        }
+
+        // Update the consoleAppender threshold to replLevel
+        if (replLevel != rootLogger.getLevel()) {
+          if (!silent) {
+
+          }
+          Logging.sparkShellThresholdLevel = replLevel
+          rootLogger.getAppenders().asScala.foreach {
+            case (_, ca: ConsoleAppender) =>
+              ca.addFilter(new SparkShellLoggingFilter())
+            case _ => // do nothing
+          }
+        }
+      }
+    }
+    Logging.initialized = true
+    // Force a call into slf4j to initialize it. Avoids this happening from multiple threads
+    // and triggering this:  http://mailman.qos.ch/pipermail/slf4j-dev/2010-April/002956.html
+    log
+  }
+
+}
+
+object Logging {
+  @volatile private var initialized = false
+  @volatile private var defaultRootLevel: Level = null
+  @volatile private var defaultSparkLog4jConfig = false
+  @volatile private var sparkShellThresholdLevel: Level = null
+  @volatile private var setLogLevelPrinted: Boolean = false
+
+  val initLock = new Object()
+  try {
+    // We use reflection here to handle the case where users remove the
+    // slf4j-to-jul bridge order to route their logs to JUL.
+    val bridgeClass = SparkClassUtils.classForName("org.slf4j.bridge.SLF4JBridgeHandler")
+    bridgeClass.getMethod("removeHandlersForRootLogger").invoke(null)
+    val installed = bridgeClass.getMethod("isInstalled").invoke(null).asInstanceOf[Boolean]
+    if (!installed) {
+      bridgeClass.getMethod("install").invoke(null)
+    }
+  } catch {
+    case e: ClassNotFoundException => // can't log anything yet so just fail silently
+  }
+
+  /**
+   * Marks the logging system as not initialized. This does a best effort at resetting the
+   * logging system to its initial state so that the next class to use logging triggers
+   * initialization again.
+   */
+  def uninitialize(): Unit = initLock.synchronized {
+    if (isLog4j2()) {
+      if (defaultSparkLog4jConfig) {
+        defaultSparkLog4jConfig = false
+        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+        context.reconfigure()
+      } else {
+        val rootLogger = LogManager.getRootLogger().asInstanceOf[Log4jLogger]
+        rootLogger.setLevel(defaultRootLevel)
+        sparkShellThresholdLevel = null
+      }
+    }
+    this.initialized  = false
+  }
+
+  def isLog4j2(): Boolean = {
+    // This distinguishes the log4j 1.2 binding, currently
+    // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
+    // org.apache.logging.slf4j.Log4jLoggerFactory
+    "org.apache.logging.slf4j.Log4jLoggerFactory"
+      .equals(LoggerFactory.getILoggerFactory.getClass.getName)
+  }
+
+  // Return true if the logger has custom configuration. It depends on:
+  // 1. If the logger isn't attched with root logger config (i.e., with custom configuration), or
+  // 2. the logger level is different to root config level (i.e., it is changed programmatically).
+  //
+  // Note that if a logger is programmatically changed log level but set to same level
+  // as root config level, we cannot tell if it is with custom configuration.
+  def loggerWithCustomConfig(logger: Log4jLogger):Boolean = {
+    val rootConfig = LogManager.getRootLogger.asInstanceOf[Log4jLogger].get()
+    (logger.get() ne rootConfig) || (logger.getLevel != rootConfig.getLevel())
+  }
+
+  /**
+   * Return true if log4j2 is initialized by default configuration which has one
+   * appender with error level. See the `org.apache.logging.log4j.core.config.DefaultConfiguration`.
+   */
+  def islog4j2DefaultConfigured(): Boolean = {
+    val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
+    rootLogger.getAppenders.isEmpty ||
+      (rootLogger.getAppenders.size() == 1 &&
+        rootLogger.getLevel == Level.ERROR &&
+        LogManager.getContext.asInstanceOf[LoggerContext]
+        .getConfiguration.isInstanceOf[DefaultConfiguration])
+  }
+
+  class SparkShellLoggingFilter extends AbstractFilter {
+    var status = LifeCycle.State.INITIALIZING
+
+    /**
+     * If sparkShellThresholdLevel is not defined, this filter is a no-op.
+     * If log level of event is not equal to root level, the event is allowed.
+     * Otherwise, the decision is made based on whether the log came from root or some custom configuration
+     *
+     * @param loggingEvent
+     * @return decision for accept/deny log event
+     */
+    override def filter(logEvent: LogEvent): Filter.Result = {
+      if (Logging.sparkShellThresholdLevel == null) {
+        Filter.Result.NEUTRAL
+      } else if (logEvent.getLevel.isMoreSpecificThan(Logging.sparkShellThresholdLevel)) {
+        Filter.Result.NEUTRAL
+      } else {
+        val logger = LogManager.getLogger(logEvent.getLoggerName).asInstanceOf[Log4jLogger]
+        if (loggerWithCustomConfig(logger)) {
+          return Filter.Result.NEUTRAL
+        }
+        Filter.Result.DENY
+      }
+    }
+
+    override def getState: LifeCycle.State = status
+
+    override def initialize(): Unit = {
+      status = LifeCycle.State.INITIALIZED
+    }
+
+    override def start(): Unit = {
+      status = LifeCycle.State.STARTED
+    }
+
+    override def stop(): Unit = {
+      status = LifeCycle.State.STOPPED
+    }
+
+    override def isStarted(): Boolean = status == LifeCycle.State.STARTED
+
+    override def isStopped: Boolean = status == LifeCycle.State.STOPPED
+  }
+}

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/main/scala/org/emma/spark/streaming/topic/internal/SparkClassUtils.scala
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/main/scala/org/emma/spark/streaming/topic/internal/SparkClassUtils.scala
@@ -1,0 +1,67 @@
+package org.emma.spark.streaming.topic.internal
+
+import scala.util.{Random, Try}
+
+trait SparkClassUtils {
+  val random = new Random()
+
+  def getSparkClassLoader: ClassLoader = getClass.getClassLoader
+
+  def getContextOrSparkClassLoader: ClassLoader =
+    Option(Thread.currentThread().getContextClassLoader).getOrElse(getSparkClassLoader)
+
+  /**
+   * Preferred alternative to Class.forName(className), as well as
+   * Class.forName(className, initialize, loader) with current thread's ContextClassLoader.
+   */
+  def classForName[C](
+      className: String,
+      initialize: Boolean = true,
+      noSparkClassLoader: Boolean = false): Class[C] = {
+    if (!noSparkClassLoader) {
+      Class.forName(className, initialize, getContextOrSparkClassLoader).asInstanceOf[Class[C]]
+    } else {
+      Class.forName(className, initialize, Thread.currentThread().getContextClassLoader)
+        .asInstanceOf[Class[C]]
+    }
+  }
+
+  // Determines whether the provided class is loadable in the current thread
+  def classIsLoadable(clazz: String): Boolean = {
+    Try {
+      classForName(clazz, initialize = false)
+    }.isSuccess
+  }
+
+  /**
+   * Returns true if and only if the underlying class is a member class.
+   *
+   * Note: jdk8u throws a "Malformed class name" error if a given class is a deeply-nested
+   * inner class (See SPARK-34607 for details).
+   * This issue has already been fixed in jdk9+, so we can remove this helper method safely if we drop the support of jdk8u.
+   */
+  def isMemberClass(cls: Class[_]): Boolean = {
+    try {
+      cls.isMemberClass
+    } catch {
+      case _: InternalError =>
+      // scalastyle:off classforname
+      // We emulate jdk8u `Class.isMemberClass` below:
+      // public boolean isMemberClass() {
+      //     return getSimpleBinaryName() != null && !isLocalOrAnonymousClass();
+      // }
+      // `getSimpleBinaryName()` returns null if a given class is a top-level class,
+      // so we replace it with `cls.getEnclosingClass != null`. The second condition checks
+      // if a given class is not a local or an anonymous class, so we replace it with
+      // `cls.getEnclosingMethod == null` because `cls.getEnclosingMethod()` return a value
+      // only in either case (JVM Spec 4.8.6).
+      //
+      // Note: the newer jdk evaluates `!isLocalOrAnonymousClass()` first,
+      // we reorder the condition to follow it.
+      cls.getEnclosingMethod == null && cls.getEnclosingClass != null
+    }
+  }
+
+}
+
+object SparkClassUtils extends SparkClassUtils

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/test/java/org/emma/spark/streaming/topic/RedisBackendCacheIT.java
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/test/java/org/emma/spark/streaming/topic/RedisBackendCacheIT.java
@@ -59,7 +59,7 @@ public class RedisBackendCacheIT {
     @BeforeAll
     public static void setUp() {
         jedis = ThreadLocal.withInitial(() -> {
-
+            return null;
         });
     }
 

--- a/spark/spark-streaming-topic/spark-streaming-pro/src/test/scala/org/emma/spark/streaming/topic/TestServer.scala
+++ b/spark/spark-streaming-topic/spark-streaming-pro/src/test/scala/org/emma/spark/streaming/topic/TestServer.scala
@@ -1,0 +1,114 @@
+package org.emma.spark.streaming.topic
+
+import org.apache.hadoop.shaded.com.nimbusds.jose.util.StandardCharset
+import org.emma.spark.streaming.topic.internal.Logging
+import org.junit.Assert.fail
+
+import java.io.{BufferedWriter, OutputStreamWriter}
+import java.net.{ServerSocket, Socket, SocketException}
+import java.util.concurrent.{ArrayBlockingQueue, CountDownLatch, TimeUnit}
+
+/** A server implemented for testing cases.
+ * TestServer will setup server with random port and passing data as input stream
+ * for spark jobs to subscribe and consume
+ **/
+class TestServer(portToBind: Int = 0) extends Logging {
+  val queueCapacity: Int = 100
+  val queue = new ArrayBlockingQueue[String](queueCapacity)
+
+  val serverSocket = new ServerSocket(portToBind)
+
+  private val startLatch = new CountDownLatch(1)
+
+  /**
+   * method of executeSocketServer executes
+   * 1. poll data from queue and wrap data into message sent message to the connected/accepted socket clients
+   * 2. also distinguish the connection times, the first connection is spark job setup signal
+   *    dataset sending operaiton only happens after the spark job setup and get ready to process data.
+   * 3.
+   */
+  def executeSocketServer(serverSocket: ServerSocket, queue: ArrayBlockingQueue[String], startLatch: CountDownLatch): Unit = {
+    while (true) {
+      logInfo("#executeSocketServer Accepting connections on port " + port)
+      val clientSocket = serverSocket.accept()
+      if (startLatch.getCount == 1) {
+        // just skip this connection, this connection is the signal to let TestServer know that client side (spark job) is just seting up
+        // not get ready to subscribe data and consume it yet.
+        if (!clientSocket.isClosed) {
+          clientSocket.close()
+        }
+        startLatch.countDown()
+      } else {
+        logInfo("#executeSocketServer new connection coming")
+        try {
+          clientSocket.setTcpNoDelay(true)
+          val outputStream = new BufferedWriter(
+            new OutputStreamWriter(clientSocket.getOutputStream, StandardCharset.UTF_8))
+
+          while (clientSocket.isConnected) {
+            val msg = queue.poll(100, TimeUnit.MILLISECONDS)
+            if (msg != null) {
+              outputStream.write(msg)
+              outputStream.flush()
+              logInfo("Message '" + msg + " ' sent")
+            }
+          }
+        } catch {
+          case e: SocketException => logError("#executeSocketServer got exception ", e)
+        } finally {
+          logInfo("#executeSockeServer connection going to be closed")
+          if (!clientSocket.isClosed) {
+            clientSocket.close()
+          }
+        }
+      }
+
+    }
+  }
+
+  val servingThread = new Thread(() => {
+    try {
+      // invoke method and send message to accepted connected client(s)
+      executeSocketServer(serverSocket, queue, startLatch);
+    } catch {
+      case ie: InterruptedException =>
+    } finally {
+      logInfo("Close Server Socket")
+      serverSocket.close()
+    }
+  })
+
+  def start(): Unit = {
+    servingThread.start()
+    // here we call the WaitFor Start this methods will return after the server socket setup successfully
+    if (!waitForStart(100000)) {
+      stop()
+
+      // if 10 seconds past the client socket still cannot get access to the server via the specific port
+      // it will trigger fail operation to stop the test
+      fail("Timeout: TestServer cannot start in 10 seconds")
+    }
+  }
+
+  /**
+   * Method defined for handling wait until the server starts.
+   * This method will return true if the server starts in "millis" milliesecionds.
+   * Otherwise, return false to indicate it's timeout.
+   */
+  def waitForStart(millis: Long): Boolean = {
+    // we will create a test connection to the server so that we can make sure it has started.
+    val socket = new Socket("localhost", port)
+
+    try {
+      startLatch.await(millis, TimeUnit.MILLISECONDS)
+    } finally {
+      if (!socket.isClosed) {
+        socket.close()
+      }
+    }
+  }
+
+  def send(msg: String):Unit = {queue.put(msg)}
+  def stop() : Unit {}
+  def port: Int = serverSocket.getLocalPort
+}


### PR DESCRIPTION
In this commit add `Logging` that copied from spark source codes, and Spark Unit Test frequently used upstream dataset 'feeder' the `TestServer`. 